### PR TITLE
Keep Alive on HTTP connection is disabled.

### DIFF
--- a/opensearchUtils/osConnection.go
+++ b/opensearchUtils/osConnection.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"net/http"
 	"os"
 	"scaling_manager/logger"
 
@@ -55,6 +56,10 @@ func InitializeOsClient(username string, password string) {
 		Addresses: []string{"http://localhost:9200"},
 		Username:  username,
 		Password:  password,
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+		},
+		MaxRetries: 5,
 	})
 	if err != nil {
 		log.Fatal.Println(err)


### PR DESCRIPTION
The server's default keep alive time is 2 hours. This keeps your http socket connection active for 2 hours even if you don't utilise it. This opens a socket for each request made via the opensearch client. As a result, there are too many open connections at any given time.

This client setting ends the http connection after the response to that request is served.