### PR TITLE
Close response Body & read purge time from user

### DIFF
--- a/fetchmetrics/fetchMetrics.go
+++ b/fetchmetrics/fetchMetrics.go
@@ -25,7 +25,7 @@ func init() {
 // 		parameters to opensearch index and deletes documents that are older than
 // 	    72 hours
 // Return:
-func FetchMetrics(pollingInterval int) {
+func FetchMetrics(pollingInterval int, purgeAfter int) {
 	ticker := time.Tick(time.Duration(pollingInterval) * time.Second)
 	for range ticker {
 		//check if current node is the master node and update the cluster stats if it is master
@@ -35,6 +35,6 @@ func FetchMetrics(pollingInterval int) {
 		//Index the the node stats
 		IndexNodeStats(ctx)
 		//Purge documents from elasticsearch index that are older than 72 hours
-		// DeleteOldDocs(ctx)
+		// DeleteOldDocs(ctx, purgeAfter)
 	}
 }

--- a/fetchmetrics/purgeOldDocs.go
+++ b/fetchmetrics/purgeOldDocs.go
@@ -3,6 +3,7 @@ package fetchmetrics
 import (
 	"context"
 	osutils "scaling_manager/opensearchUtils"
+	"strconv"
 )
 
 // Input:
@@ -14,20 +15,20 @@ import (
 //	Deletes documents that older than 72 hours
 //
 // Return:
-func DeleteOldDocs(ctx context.Context) {
+func DeleteOldDocs(ctx context.Context, purgeAfter int) {
 	var jsonQuery = []byte(`{
-                "query": {
-                  "bool": {
-                          "filter": {
-                                  "range": {
-                                                  "Timestamp": {
-                                                                  "lte":"now-72h"
-                                                  }
-                                          }
-                                  }
-                          }
-                  }
-          }`)
+				  "query": {
+				    "bool": {
+				      "filter": {
+				        "range": {
+				          "Timestamp": {
+				            "lte": "now-` + strconv.Itoa(purgeAfter) + `h"
+				          }
+				        }
+				      }
+				    }
+				  }
+				}`)
 	deleteResp, err := osutils.DeleteWithQuery(ctx, jsonQuery)
 	if err != nil {
 		log.Panic.Println("Unable to execute request: ", err)

--- a/fetchmetrics/purgeOldDocs.go
+++ b/fetchmetrics/purgeOldDocs.go
@@ -6,9 +6,13 @@ import (
 )
 
 // Input:
-//      ctx (context.Context): Request-scoped data that transits processes and APIs.
-// Description: 
-//      Deletes documents that older than 72 hours
+//
+//	ctx (context.Context): Request-scoped data that transits processes and APIs.
+//
+// Description:
+//
+//	Deletes documents that older than 72 hours
+//
 // Return:
 func DeleteOldDocs(ctx context.Context) {
 	var jsonQuery = []byte(`{
@@ -29,5 +33,6 @@ func DeleteOldDocs(ctx context.Context) {
 		log.Panic.Println("Unable to execute request: ", err)
 		panic(err)
 	}
+	defer deleteResp.Body.Close()
 	log.Info.Println("Document deleted: ", deleteResp)
 }


### PR DESCRIPTION
The response returned from the osapi was creating too many open socket connections. 
Closed the response Body after use.
Read the purge time for Fetched metrics from user config