### PR TITLE
Check cluster health for scale down

### DIFF
--- a/provision/trigger.go
+++ b/provision/trigger.go
@@ -37,8 +37,7 @@ func GetRecommendation(state *State, recommendationQueue []map[string]string, cl
 		}
 
 		state.GetCurrentState()
-		if clusterCurrent.ClusterStatus == "green" && state.CurrentState == "normal" {
-			// Fill in the command struct with the recommendation queue and config file and trigger the recommendation.
+		if state.CurrentState == "normal" {
 			var subMatch []string
 			var task string
 			for task, _ = range recommendationQueue[0] {
@@ -47,9 +46,14 @@ func GetRecommendation(state *State, recommendationQueue []map[string]string, cl
 
 			numNodes, _ := strconv.Atoi(subMatch[2])
 			operation := subMatch[1]
+			// Call scale down provisioning only when the cluster status is green. No recommended to scale down when cluster is in yellow or red state
+			if operation == "scale_down" && clusterCurrent.ClusterStatus != "green" {
+				log.Warn.Println("Recommendation can not be provisioned as open search cluster is unhealthy for a scale_down. \n Discarding this recommendation")
+				return
+			}
 			TriggerProvision(clusterCfg, usrCfg, state, numNodes, operation, recommendationQueue[0][task])
 		} else {
-			log.Warn.Println("Recommendation can not be provisioned as open search cluster is already in provisioning phase or the cluster isn't healthy yet")
+			log.Warn.Println("Recommendation can not be provisioned as open search cluster is already in provisioning phase.")
 		}
 	}
 }

--- a/provision/trigger.go
+++ b/provision/trigger.go
@@ -7,16 +7,17 @@ import (
 	"scaling_manager/cluster_sim"
 	"scaling_manager/config"
 	"strconv"
+	"time"
 )
 
 var ctx = context.Background()
 
 // Input:
 //
-//	             state (*State): A pointer to the state struct which is state maintained in OS document
-//			recommendationQueue ([]map[string]string): Recommendations provided by the recommendation engine in the form of an array of strings
-//	             clusterCfg (config.ClusterDetails): Cluster Level config details
-//	             usrCfg (config.UserConfig): User defined config for applicatio behavior
+//	state (*State): A pointer to the state struct which is state maintained in OS document
+//	recommendationQueue ([]map[string]string): Recommendations provided by the recommendation engine in the form of an array of strings
+//	clusterCfg (config.ClusterDetails): Cluster Level config details
+//	usrCfg (config.UserConfig): User defined config for applicatio behavior
 //
 // Description:
 //
@@ -25,13 +26,13 @@ var ctx = context.Background()
 //	Triggers the provisioning
 //
 // Return:
-func GetRecommendation(state *State, recommendationQueue []map[string]string, clusterCfg config.ClusterDetails, usrCfg config.UserConfig) {
+func GetRecommendation(state *State, recommendationQueue []map[string]string, clusterCfg config.ClusterDetails, usrCfg config.UserConfig, t *time.Time) {
 	var clusterCurrent cluster.ClusterDynamic
 	scaleRegexString := `(scale_up|scale_down)_by_([0-9]+)`
 	scaleRegex := regexp.MustCompile(scaleRegexString)
 	if len(recommendationQueue) > 0 {
 		if usrCfg.MonitorWithSimulator {
-			clusterCurrent = cluster_sim.GetClusterCurrent()
+			clusterCurrent = cluster_sim.GetClusterCurrent(usrCfg.IsAccelerated)
 		} else {
 			clusterCurrent = cluster.GetClusterCurrent()
 		}
@@ -51,7 +52,7 @@ func GetRecommendation(state *State, recommendationQueue []map[string]string, cl
 				log.Warn.Println("Recommendation can not be provisioned as open search cluster is unhealthy for a scale_down. \n Discarding this recommendation")
 				return
 			}
-			TriggerProvision(clusterCfg, usrCfg, state, numNodes, operation, recommendationQueue[0][task])
+			TriggerProvision(clusterCfg, usrCfg, state, numNodes, t, operation, recommendationQueue[0][task])
 		} else {
 			log.Warn.Println("Recommendation can not be provisioned as open search cluster is already in provisioning phase.")
 		}


### PR DESCRIPTION
1. Do not provision scale down if the cluster health is not green.
2. Discard the recommendation and the recommendation will be provisioned only when cluster is back to green state