### PR TITLE
Wait for next provision & time update

### DIFF
--- a/provision/state_functions.go
+++ b/provision/state_functions.go
@@ -25,7 +25,7 @@ func InitializeDocId() {
 // Input:
 //
 // Caller:
-//		Object of type State
+//	Object of type State
 //
 // Description:
 //      GetCurrentState will update the state variable pointer such that it is in sync with the updated values.
@@ -47,6 +47,8 @@ func (s *State) GetCurrentState() {
 	if searchResponse.Status() == "404 Not Found" {
 		//Setting the initial state
 		s.CurrentState = "normal"
+		s._documentType = "State"
+		s.StatTag = "State"
 		s.UpdateState()
 		return
 	}


### PR DESCRIPTION
1. Updated all time field to epoch milliseconds
2. Added _documenType field needed for SnappyFlow UI
3. Added following logics in trigger.go: a. Select the largest Decision Period among the rules met for recommendation b. Compare the time difference with the last successful Provision that took place c. Trigger provision only if they don't coincide