### PR TITLE
Max|Min Nodes Check & move logic to function

### DIFF
--- a/provision/trigger.go
+++ b/provision/trigger.go
@@ -163,6 +163,7 @@ func comparePreviousProvision(ruleResponsible string, operation string) bool {
 	resp, err := osutils.SearchQuery(context.Background(), []byte(getLatestProvisionQuery()))
 	if err != nil {
 		log.Error.Println("Error querying the last provision document frm Opensearch", err)
+		return false
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
1. Added the check to check for max nodes configured in config file and warn if the scale_up exceeds the number
2. Similarly check the min nodes before provisioning scale_down
3. Moved the check last provisioned time before actual provision into a different method. To make the code more readable