### PR TITLE
Ansible extra vars as map[string]interface{}

### DIFF
--- a/cluster/cluster_level_parameters.go
+++ b/cluster/cluster_level_parameters.go
@@ -59,26 +59,26 @@ type Node struct {
 // This struct will contain the static metrics of the cluster.
 type ClusterStatic struct {
 	// ClusterName indicates the Cluster name for the OpenSearch cluster.
-	ClusterName string `yaml:"cluster_name" validate:"required,isValidName"`
+	ClusterName string `yaml:"cluster_name" validate:"required,isValidName" json:"cluster_name"`
 	// IpAddress indicate the master node IP for the OpenSearch cluster.
-	IpAddress string `yaml:"ip_address" validate:"required,ip"`
+	IpAddress string `yaml:"ip_address" validate:"required,ip" json:"ip_address"`
 	// CloudType indicate the type of the cloud service where the OpenSearch cluster is deployed.
-	CloudType string `yaml:"cloud_type" validate:"required,oneof=AWS GCP AZURE"`
+	CloudType string `yaml:"cloud_type" validate:"required,oneof=AWS GCP AZURE" json:"cloud_type"`
 	// BaseNodeType indicate the instance type of the node.
 	// This parameters depends on the cloud service.
-	BaseNodeType string `yaml:"base_node_type" validate:"required"`
+	BaseNodeType string `yaml:"base_node_type" validate:"required" json:"base_node_type"`
 	// NumCpusPerNode indicates the number of the CPU core running on a node in a cluster.
-	NumCpusPerNode int `yaml:"number_cpus_per_node" validate:"required,min=1"`
+	NumCpusPerNode int `yaml:"number_cpus_per_node" validate:"required,min=1" json:"number_cpus_per_node"`
 	// RAMPerNodeInGB indicates the RAM size in GB running on a node in a cluster.
-	RAMPerNodeInGB int `yaml:"ram_per_node_in_gb" validate:"required,min=1"`
+	RAMPerNodeInGB int `yaml:"ram_per_node_in_gb" validate:"required,min=1" json:"ram_per_node_in_gb"`
 	// DiskPerNodeInGB indicates the Disk size in GB running on a node in a cluster.
-	DiskPerNodeInGB int `yaml:"disk_per_node_in_gb" validate:"required,min=1"`
+	DiskPerNodeInGB int `yaml:"disk_per_node_in_gb" validate:"required,min=1" json:"disk_per_node_in_gb"`
 	// NumMaxNodesAllowed indicates the number of maximum allowed node present in the cluster.
 	// Based on this value we will determine whether to scale out further or not.
-	MaxNodesAllowed int `yaml:"max_nodes_allowed" validate:"required,min=1"`
+	MaxNodesAllowed int `yaml:"max_nodes_allowed" validate:"required,min=1" json:"max_nodes_allowed"`
 	// MinNodesAllowed indicates the number of minimum nodes a cluster should have at any point
 	// Based on this value we will determine whether to scale in further or not.
-	MinNodesAllowed int `yaml:"min_nodes_allowed" validate:"required,min=1"`
+	MinNodesAllowed int `yaml:"min_nodes_allowed" validate:"required,min=1" json:"min_nodes_allowed"`
 }
 
 // This struct will contain the dynamic metrics of the cluster.

--- a/config/config.go
+++ b/config/config.go
@@ -29,29 +29,29 @@ func init() {
 // This struct contains the OS Admin Username and OS Admin Password via which we can connect to OS cluster.
 type OsCredentials struct {
 	// OsAdminUsername indicates the OS Admin Username via which OS client can connect to OS Cluster.
-	OsAdminUsername string `yaml:"os_admin_username" validate:"required"`
+	OsAdminUsername string `yaml:"os_admin_username" validate:"required" json:"os_admin_username"`
 	// OsAdminPassword indicates the OS Admin Password via which OS client can connect to OS Cluster.
-	OsAdminPassword string `yaml:"os_admin_password" validate:"required"`
+	OsAdminPassword string `yaml:"os_admin_password" validate:"required" json:"os_admin_password"`
 }
 
 // This struct contains the Cloud Secret Key and Access Key via which we can connect to the cloud.
 type CloudCredentials struct {
 	// SecretKey indicates the Secret key for connecting to the cloud.
-	SecretKey string `yaml:"secret_key" validate:"required"`
+	SecretKey string `yaml:"secret_key" validate:"required" json:"secret_key"`
 	// AccessKey indicates the Access key for connecting to the cloud.
-	AccessKey string `yaml:"access_key" validate:"required"`
+	AccessKey string `yaml:"access_key" validate:"required" json:"access_key"`
 }
 
 // This struct contains the data structure to parse the cluster details present in the configuration file.
 type ClusterDetails struct {
 	// ClusterStatic indicates the static configuration for the cluster.
 	cluster.ClusterStatic `yaml:",inline"`
-	SshUser               string           `yaml:"os_user" validate:"required"`
-	OpensearchVersion     string           `yaml:"os_version" validate:"required"`
-	OpensearchHome        string           `yaml:"os_home" validate:"required"`
-	DomainName            string           `yaml:"domain_name" validate:"required"`
-	OsCredentials         OsCredentials    `yaml:"os_credentials"`
-	CloudCredentials      CloudCredentials `yaml:"cloud_credentials"`
+	SshUser               string           `yaml:"os_user" validate:"required" json:"os_user"`
+	OpensearchVersion     string           `yaml:"os_version" validate:"required" json:"os_version"`
+	OpensearchHome        string           `yaml:"os_home" validate:"required" json:"os_home"`
+	DomainName            string           `yaml:"domain_name" validate:"required" json:"domain_name"`
+	OsCredentials         OsCredentials    `yaml:"os_credentials" json:"os_credentials"`
+	CloudCredentials      CloudCredentials `yaml:"cloud_credentials" json:"cloud_credentials"`
 }
 
 // Config for application behaviour from user
@@ -59,7 +59,7 @@ type UserConfig struct {
 	MonitorWithLogs      bool `yaml:"monitor_with_logs"`
 	MonitorWithSimulator bool `yaml:"monitor_with_simulator"`
 	PurgeAfter           int  `yaml:"purge_old_docs_after_hours"`
-	PollingInterval      int  `yaml:"polling_interval_in_secs"`
+	PollingInterval      int  `yaml:"polling_interval_in_secs" validate:"required"`
 	IsAccelerated        bool `yaml:"is_accelerated"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -58,7 +58,7 @@ type ClusterDetails struct {
 type UserConfig struct {
 	MonitorWithLogs      bool `yaml:"monitor_with_logs"`
 	MonitorWithSimulator bool `yaml:"monitor_with_simulator"`
-	PurgeAfter           int  `yaml:"purge_old_docs_after_hours"`
+	PurgeAfter           int  `yaml:"purge_old_docs_after_hours" validate:"required"`
 	PollingInterval      int  `yaml:"polling_interval_in_secs" validate:"required"`
 	IsAccelerated        bool `yaml:"is_accelerated"`
 }


### PR DESCRIPTION
1. Changing the logic to pass variables to ansible script from file to map
2. To avoid storing secrets in the vars file
3. Added json tag to convert struct to map[string]interface{} which will be used to pass it to ansible script