### PR TITLE
Terminate the instance

### DIFF
--- a/ansible_scripts/roles/scale_down/tasks/main.yml
+++ b/ansible_scripts/roles/scale_down/tasks/main.yml
@@ -52,10 +52,6 @@
         name: 'opensearch'
         state: stopped
 
-    - name: Stop the instance
-      become: true
-      shell: "shutdown -h +4" 
-
     - name: Clear the exclusion of node after shutdown
       become: true
       become_user: root

--- a/provision/awsScale.go
+++ b/provision/awsScale.go
@@ -2,6 +2,7 @@ package provision
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -11,13 +12,13 @@ import (
 //
 // Description:
 //
-//	             Spins a new ec2 instance on AWS using the launchTemplate specified.
-//			Returns the ip address of the created ec2 instance for further configuration of Opensearch
+//	Spins a new ec2 instance on AWS using the launchTemplate specified.
+//	Returns the ip address of the created ec2 instance for further configuration of Opensearch
 //
 // Return:
 //
 //	(string, error): Returns the private ip address of the spinned node and error if any
-func SpinNewVm() (string, error) {
+func SpinNewVm(launchTemplateId string, launchTemplateVersion string) (string, error) {
 	sess, err := session.NewSession(&aws.Config{
 		Region:      aws.String("us-west-2"),
 		Credentials: credentials.NewSharedCredentials("", ""),
@@ -25,12 +26,10 @@ func SpinNewVm() (string, error) {
 
 	// Create EC2 service client
 	svc := ec2.New(sess)
-	launchTemplateId := ""      // Replace from config file
-	launchTmeplateVersion := "" // Replace from config file
 
 	launchTemplate := &ec2.LaunchTemplateSpecification{
 		LaunchTemplateId: &launchTemplateId,
-		Version:          &launchTmeplateVersion,
+		Version:          &launchTemplateVersion,
 	}
 
 	// Specify the details of the instance that you want to create.
@@ -48,7 +47,7 @@ func SpinNewVm() (string, error) {
 		return "", err
 	}
 
-	log.Info.Println("Created instance, Instacne ID: ", *runResult.Instances[0].InstanceId)
+	log.Info.Println("Created instance, Instance ID: ", *runResult.Instances[0].InstanceId)
 	private_ip := *runResult.Instances[0].PrivateIpAddress
 	log.Info.Println("Created instance, Private IP: ", *runResult.Instances[0].PrivateIpAddress)
 
@@ -89,4 +88,68 @@ func SpinNewVm() (string, error) {
 	}
 	return private_ip, nil
 
+}
+
+// Input:
+//
+//	privateIp (string): private ip address of the instance that needs to be terminated
+//
+// Description:
+//
+//	Uses the private ip address passed as input to identify the instance id.
+//	Terminates the ec2 instance.
+//
+// Return:
+//
+//	(error): Returns error if any while terminating the instance
+func TerminateInstance(privateIp string) error {
+	sess, err := session.NewSession(&aws.Config{
+		Region:      aws.String("us-west-2"),
+		Credentials: credentials.NewSharedCredentials("", ""),
+	})
+
+	// Create EC2 service client
+	svc := ec2.New(sess)
+
+	describeInput := &ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("private-ip-address"),
+				Values: []*string{
+					aws.String(privateIp),
+				},
+			},
+		},
+	}
+
+	describeResult, descErr := svc.DescribeInstances(describeInput)
+
+	if descErr != nil {
+		log.Info.Println("Could not get the description of instance", descErr)
+		return err
+	}
+
+	instanceId := *describeResult.Reservations[0].Instances[0].InstanceId
+
+	log.Info.Println("Terminating instance with ID: ", instanceId)
+
+	input := &ec2.TerminateInstancesInput{
+		InstanceIds: []*string{
+			aws.String(instanceId),
+		},
+	}
+
+	result, err := svc.TerminateInstances(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				log.Error.Println(aerr.Error())
+			}
+		}
+		return err
+	}
+
+	log.Info.Println(result)
+	return nil
 }

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -193,7 +193,7 @@ func ScaleOut(clusterCfg config.ClusterDetails, usrCfg config.UserConfig, state 
 			}
 		} else {
 			var err error
-			newNodeIp, err = SpinNewVm()
+			newNodeIp, err = SpinNewVm(clusterCfg.LaunchTemplateId, clusterCfg.LaunchTemplateVersion)
 			if err != nil {
 				return false, err
 			}
@@ -356,6 +356,16 @@ func ScaleIn(clusterCfg config.ClusterDetails, usrCfg config.UserConfig, state *
 				log.Fatal.Println(err)
 				return false, ansibleErr
 			}
+		}
+		state.PreviousState = state.CurrentState
+		state.CurrentState = "provisioned_scaledown_on_cluster"
+		state.UpdateState()
+		fallthrough
+	case "provisioned_scaledown_on_cluster":
+		terminateErr := TerminateInstance(removeNodeIp)
+		if terminateErr != nil {
+			log.Fatal.Println(terminateErr)
+			return false, terminateErr
 		}
 		state.PreviousState = state.CurrentState
 		state.CurrentState = "provisioning_scaledown_completed"


### PR DESCRIPTION
1. Removed shutdown logic from ansible script
2. Renamed scaleUpNode.go with awsScale.go
3. Added new stage for scale down process 
     a. ansible script will only remove the node from the cluster and stop Opensearch on it 
     b. TerminateInstance() will take care of terminating the instance using the node's private IP
4. Pass launchTemplateId and launchTemplateVersion from config to spin a new node