### PR TITLE
Remove exists check for file

### DIFF
--- a/install_scaling_manager.yaml
+++ b/install_scaling_manager.yaml
@@ -66,10 +66,6 @@
 - name: Update secret
   hosts: all
   tasks:
-  - name: Check that the secret.txt exists
-    stat:
-      path: /usr/local/scaling_manager_lib/.secret.txt
-    register: stat_result
   - name: Transfer the secret file
     become: yes
     copy:
@@ -77,7 +73,6 @@
         dest: /usr/local/scaling_manager_lib
         owner: '{{ user | default("ubuntu") }}'
         group: '{{ group | default("ubuntu") }}'
-    when: not stat_result.stat.exists
   tags: update_secret
 - name: Update Config
   hosts: all


### PR DESCRIPTION
1. Remove the check for .secret.txt exists or not while copying it from master node.
2. This was restricting the copy, when secret gets regenrated