### PR TITLE
Remove gather_facts

### DIFF
--- a/ansible_scripts/scaleUpPlaybook.yml
+++ b/ansible_scripts/scaleUpPlaybook.yml
@@ -44,7 +44,6 @@
     become: yes
 
 - hosts: new_node
-  gather_facts: no
   name: Custom role-based tasks
   become: yes
 


### PR DESCRIPTION
Remove gather facts for custom role.
Since python is already installed before this call. It can used by tasks in custom_role