### PR TITLE
Changed network.target to network-online.target

### DIFF
--- a/crypto_sm.service
+++ b/crypto_sm.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Crypto module for OpenSearch Scaling Manager.
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=simple 

--- a/fetchmetrics.service
+++ b/fetchmetrics.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Fetch Metrics module for OpenSearch Scaling Manager.
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=simple 

--- a/scaling_manager.service
+++ b/scaling_manager.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=OpenSearch Scaling Manager(scale the opensearch cluster based on rules.)
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=simple 


### PR DESCRIPTION
1. **network.target** has very little meaning during start-up. It only indicates that the network management stack is up after it has been reached. Whether any network interfaces are already configured when it is reached is undefined. Its primary purpose is for ordering things properly at shutdown 
2. **network-online.target** is a target that actively waits until the nework is "up", where the definition of "up" is defined by the network management software. Usually it indicates a configured, routable IP address of some kind. Its primary purpose is to actively delay activation of services until the network is set up. It is an active target, meaning that is may be pulled in by the services requiring the network to be up, but is not pulled in by the network management service itself

That is why changing from network.tartget to network-online.target to get started when node is restarted.