### PR TITLE
Reroute/scaleDownLog/MaxHeap

### DIFF
--- a/ansible_scripts/docs.py
+++ b/ansible_scripts/docs.py
@@ -4,8 +4,16 @@ import sys
 import time
 from requests.auth import HTTPBasicAuth
 url = "http://"+sys.argv[4]+":9200/_nodes/"+sys.argv[3]+"/stats/indices"
+health_url = "http://"+sys.argv[4]+":9200/_cluster/health"
 docs_count = 1
 while docs_count != 0:
+  unassigned_shards = requests.get(health_url, auth = HTTPBasicAuth(sys.argv[1],sys.argv[2]))
+  json_resp = unassigned_shards.json()
+  if json_resp['unassigned_shards'] > 0 {
+    print("Still moving shards across the cluster.")
+    print("\nWARNING!! But there are unassigned shards in the cluster: ", json_resp['unassigned_shards'])
+    print("\n Please take a look and remove the exclusion of node from _cluster/settings and restart scaling manager if you do not want to remove this node\n")
+  }
   response = requests.get(url,auth = HTTPBasicAuth(sys.argv[1],sys.argv[2]))
   json_obj = response.json()
   node_id= list(json_obj['nodes'].keys())

--- a/ansible_scripts/scaleUpPlaybook.yml
+++ b/ansible_scripts/scaleUpPlaybook.yml
@@ -31,12 +31,25 @@
   - name: Extracting RAM size
     set_fact:
       RAMKB: "{{ RAM_Output.stdout.split() }}"
+
   - name: Conversion from KB to GB of RAM Size
     set_fact:
       RAM: "{{ RAMKB[1] | int /  1000000 }}"
+
   - name: Rounding off the RAM size
     set_fact:
       RAMGB: "{{ RAM | float | round(0,'common') * (jvm_factor|float) }}"
+
+  - name: Check for Heap allocation not more than 32 GB
+    fail:
+      msg: Will change Heap allocation from "{{ RAMGB }}"GB to 32 GB for optimized usage of RAM
+    when: RAMGB | int > 32
+    ignore_errors: True
+
+  - name: Change HEAP if > 32 GB
+    set_fact:
+      RAMGB: "{{ RAMGB if (RAMGB|int < 32) else 32 }}"
+
   gather_facts: no
   name: Scale-up role-based playbook
   become: yes

--- a/opensearchUtils/apiCalls.go
+++ b/opensearchUtils/apiCalls.go
@@ -197,3 +197,21 @@ func DeleteWithQuery(ctx context.Context, jsonQuery []byte) (*osapi.Response, er
 		Body:  bytes.NewReader(jsonQuery),
 	}.Do(ctx, osClient)
 }
+
+// Input:
+//
+//	ctx (context.Context): Request-scoped data that transits processes and APIs.
+//
+// Description:
+//
+//	Calls the osapi ClusterRerouteRequest with true and returns the response
+//
+// Return:
+//
+//	(*osapi.Response, error): Returns the api response and error if any
+func RerouteRetryFailed(ctx context.Context) (*osapi.Response, error) {
+	retry := true
+	return osapi.ClusterRerouteRequest{
+		RetryFailed: &retry,
+	}.Do(ctx, osClient)
+}

--- a/opensearchUtils/osConnection.go
+++ b/opensearchUtils/osConnection.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"github.com/maplelabs/opensearch-scaling-manager/logger"
 	"net/http"
 	"os"
-	"github.com/maplelabs/opensearch-scaling-manager/logger"
 
 	opensearch "github.com/opensearch-project/opensearch-go"
 	osapi "github.com/opensearch-project/opensearch-go/opensearchapi"


### PR DESCRIPTION
1. Added reroute mechanism if there are unassigned shards
2. Added log in scaleDown ansible to inform if there are any unassigned shards
3. Set Heap allocation max value to be 32 GB even if user config crosses it