### PR TITLE
Resolving issue with copy command.

### DIFF
--- a/install_scaling_manager.yaml
+++ b/install_scaling_manager.yaml
@@ -72,7 +72,7 @@
     become: yes
     copy:
         src: "{{ secret_path | default('/usr/local/scaling_manager_lib/.secret.txt') }}"
-        dest: /usr/local/scaling_manager_lib
+        dest: /usr/local/scaling_manager_lib/
         owner: '{{ user | default("ubuntu") }}'
         group: '{{ group | default("ubuntu") }}'
   tags: update_secret
@@ -83,7 +83,7 @@
     become: yes
     copy:
         src: "{{ config_path | default('/usr/local/scaling_manager_lib/config.yaml') }}"
-        dest: /usr/local/scaling_manager_lib
+        dest: /usr/local/scaling_manager_lib/
         owner: '{{ user | default("ubuntu") }}'
         group: '{{ group | default("ubuntu") }}'
   tags: update_config


### PR DESCRIPTION
If update_config and update_secret was done before installation then it failed the complete installation because destination was not containing the /, due to which the copy command was copying config.yaml as destination name. Added / to create a directory if it does not exist on the remote.