### PR TITLE
Start opensearch after custom role is executed

### DIFF
--- a/ansible_scripts/roles/scale_down/tasks/main.yml
+++ b/ansible_scripts/roles/scale_down/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for scale_down
     - name: Scale down | Stop opensearch
       become: true
-      service:
+      systemd:
         name: 'opensearch'
         state: stopped
 
@@ -21,9 +21,10 @@
 
     - name: Scale down | Restart opensearch if cluster state is red
       become: true
-      service:
+      systemd:
         name: 'opensearch'
         state: started
+        enabled: yes
       when: "cluster_health.json.status == 'red'"
 
     - name: Scale Down | Fail if the status was red

--- a/ansible_scripts/roles/scale_up/tasks/security.yml
+++ b/ansible_scripts/roles/scale_up/tasks/security.yml
@@ -165,17 +165,6 @@
     line: "#plugins.security.audit.type: internal_opensearch"
   become: yes
     
-- name: Security Plugin configuration | Restart opensearch with security configuration
-  systemd:
-    name: opensearch
-    state: restarted
-    enabled: yes   
-  become: yes
-
-- name: Wait for server to restart
-  wait_for: host={{ hostvars[inventory_hostname]['ansible_private_host'] }} port={{os_api_port}} delay=60 connect_timeout=1
-  become: yes
-
 - name: Security Plugin configuration | Cleanup local temporary directory
   local_action:
     module: file

--- a/ansible_scripts/scaleDownPlaybook.yml
+++ b/ansible_scripts/scaleDownPlaybook.yml
@@ -30,7 +30,7 @@
       backup: yes
     with_items: "{{ groups['remove_node'] }}"
 
-- hosts: new_node
+- hosts: localhost
   name: Custom role-based tasks for scale down
   become: yes
 

--- a/ansible_scripts/scaleUpPlaybook.yml
+++ b/ansible_scripts/scaleUpPlaybook.yml
@@ -76,3 +76,16 @@
 
   roles:
     - custom_scaleup_role
+
+  post_tasks:
+    - name: Start opensearch after successful installation and custom role
+      systemd:
+        daemon_reload: true
+        name: 'opensearch'
+        state: started
+        enabled: yes
+      become: yes
+
+    - name: Wait for server to restart
+      wait_for: host={{ hostvars[inventory_hostname]['ansible_private_host'] }} port={{os_api_port}} delay=60 connect_timeout=1
+      become: yes


### PR DESCRIPTION
1. Moved opensearch start logic to execute after custom role execution to make sure no allocation happens until the execution of script is completed
2. Updated service module to systemd on scaleDown scrcipt
3. Changed hosts to "localhost" for custom scale down role to execute on